### PR TITLE
fix a bug in retreive-tweets.py

### DIFF
--- a/retrieve-tweets/retrieve-tweets.py
+++ b/retrieve-tweets/retrieve-tweets.py
@@ -41,7 +41,7 @@ def main():
 		fin = codecs.open(args.id_list_file, 'r', 'utf-8')
 		for tweetid in fin:
 			tweetid = tweetid.strip()
-			if not (tweetid + '.txt') in os.listdir('args.outputpath'):
+			if not (tweetid + '.txt') in os.listdir(args.outputpath):
 				try:
 					tweet = twitter.show_status(id=tweetid)
 					fout  = codecs.open(str(args.outputpath) + tweetid + '.txt', 'w', 'utf-8')


### PR DESCRIPTION
Fix the "No such file or directory: 'args.outputpath'" error when launching retreive-tweets.py with valid arguments.
